### PR TITLE
Implement numerical features and episodic memory

### DIFF
--- a/arc_solver/features.py
+++ b/arc_solver/features.py
@@ -18,51 +18,57 @@ from .canonical import canonicalize_D4
 
 def extract_task_features(train_pairs: List[Tuple[Array, Array]]) -> Dict[str, Any]:
     """Extract a comprehensive feature vector from training pairs.
-    
+
     These features capture task-level properties that can help predict which
     DSL operations are likely to be relevant for solving the task.
     """
+
+    # Ensure arrays are integer typed for canonicalisation
     try:
-        train_pairs = [
-            (canonicalize_D4(inp), canonicalize_D4(out))
+        original_pairs = [
+            (np.asarray(inp, dtype=int), np.asarray(out, dtype=int))
             for inp, out in train_pairs
         ]
-    except TypeError as exc:
+        canonical_pairs = [
+            (canonicalize_D4(inp), canonicalize_D4(out))
+            for inp, out in original_pairs
+        ]
+    except Exception as exc:
         raise ValueError(f"invalid grid in train_pairs: {exc}") from exc
 
     features: Dict[str, Any] = {}
-    
-    # Basic grid statistics
-    input_shapes = [inp.shape for inp, _ in train_pairs]
-    output_shapes = [out.shape for _, out in train_pairs]
-    
+
+    # Basic grid statistics using original shapes
+    input_shapes = [inp.shape for inp, _ in original_pairs]
+    output_shapes = [out.shape for _, out in original_pairs]
+
     features.update({
-        'num_train_pairs': len(train_pairs),
+        'num_train_pairs': len(original_pairs),
         'input_height_mean': np.mean([s[0] for s in input_shapes]),
         'input_width_mean': np.mean([s[1] for s in input_shapes]),
         'output_height_mean': np.mean([s[0] for s in output_shapes]),
         'output_width_mean': np.mean([s[1] for s in output_shapes]),
-        'shape_preserved': all(inp.shape == out.shape for inp, out in train_pairs),
+        'shape_preserved': all(inp.shape == out.shape for inp, out in original_pairs),
         'size_ratio_mean': np.mean([
             (out.shape[0] * out.shape[1]) / (inp.shape[0] * inp.shape[1])
-            for inp, out in train_pairs
+            for inp, out in original_pairs
         ]),
     })
-    
-    # Color analysis
-    input_colors = []
-    output_colors = []
-    color_mappings = []
-    
-    for inp, out in train_pairs:
+
+    # Color analysis on canonical pairs
+    input_colors: List[int] = []
+    output_colors: List[int] = []
+    color_mappings: List[int] = []
+
+    for inp, out in canonical_pairs:
         inp_hist = histogram(inp)
         out_hist = histogram(out)
         input_colors.append(len(inp_hist))
         output_colors.append(len(out_hist))
-        
+
         # Try to detect color mappings
         if inp.shape == out.shape:
-            mapping = {}
+            mapping: Dict[int, int] = {}
             valid_mapping = True
             for i_val, o_val in zip(inp.flatten(), out.flatten()):
                 if i_val in mapping and mapping[i_val] != o_val:
@@ -71,49 +77,51 @@ def extract_task_features(train_pairs: List[Tuple[Array, Array]]) -> Dict[str, A
                 mapping[i_val] = o_val
             if valid_mapping:
                 color_mappings.append(len(mapping))
-    
+
     features.update({
         'input_colors_mean': np.mean(input_colors),
         'output_colors_mean': np.mean(output_colors),
-        'background_color_consistent': len(set(bg_color(inp) for inp, _ in train_pairs)) == 1,
+        'background_color_consistent': len(set(bg_color(inp) for inp, _ in canonical_pairs)) == 1,
         'has_color_mapping': len(color_mappings) > 0,
         'color_mapping_size': np.mean(color_mappings) if color_mappings else 0,
     })
-    
-    # Object analysis
-    input_obj_counts = []
-    output_obj_counts = []
-    
-    for inp, out in train_pairs:
+
+    # Object analysis on canonical pairs
+    input_obj_counts: List[int] = []
+    output_obj_counts: List[int] = []
+
+    for inp, out in canonical_pairs:
         inp_objects = connected_components(inp)
         out_objects = connected_components(out)
         input_obj_counts.append(len(inp_objects))
         output_obj_counts.append(len(out_objects))
-    
+
     features.update({
         'input_objects_mean': np.mean(input_obj_counts),
         'output_objects_mean': np.mean(output_obj_counts),
-        'object_count_preserved': np.mean([
+        'object_count_preserved': all(
             len(connected_components(inp)) == len(connected_components(out))
-            for inp, out in train_pairs
-        ]),
+            for inp, out in canonical_pairs
+        ),
     })
-    
-    # Transformation hints
+
+    # Transformation hints from original pairs
     features.update({
-        'likely_rotation': _detect_rotation_patterns(train_pairs),
-        'likely_reflection': _detect_reflection_patterns(train_pairs),
-        'likely_translation': _detect_translation_patterns(train_pairs),
-        'likely_recolor': _detect_recolor_patterns(train_pairs),
-        'likely_crop': _detect_crop_patterns(train_pairs),
-        'likely_pad': _detect_pad_patterns(train_pairs),
+        'likely_rotation': _detect_rotation_patterns(original_pairs),
+        'likely_reflection': _detect_reflection_patterns(original_pairs),
+        'likely_translation': _detect_translation_patterns(original_pairs),
+        'likely_recolor': _detect_recolor_patterns(original_pairs),
+        'likely_crop': _detect_crop_patterns(original_pairs),
+        'likely_pad': _detect_pad_patterns(original_pairs),
     })
-    
+
     return features
 
 
 def _detect_rotation_patterns(train_pairs: List[Tuple[Array, Array]]) -> float:
     """Detect if rotation transformations are likely."""
+    if not train_pairs:
+        return 0.0
     rotation_score = 0.0
     for inp, out in train_pairs:
         if inp.shape[0] == inp.shape[1] and out.shape[0] == out.shape[1]:
@@ -127,6 +135,8 @@ def _detect_rotation_patterns(train_pairs: List[Tuple[Array, Array]]) -> float:
 
 def _detect_reflection_patterns(train_pairs: List[Tuple[Array, Array]]) -> float:
     """Detect if reflection transformations are likely."""
+    if not train_pairs:
+        return 0.0
     reflection_score = 0.0
     for inp, out in train_pairs:
         if inp.shape == out.shape:
@@ -139,7 +149,7 @@ def _detect_reflection_patterns(train_pairs: List[Tuple[Array, Array]]) -> float
 
 def _detect_translation_patterns(train_pairs: List[Tuple[Array, Array]]) -> float:
     """Detect if translation transformations are likely."""
-    if not all(inp.shape == out.shape for inp, out in train_pairs):
+    if not train_pairs or not all(inp.shape == out.shape for inp, out in train_pairs):
         return 0.0
     
     translation_score = 0.0
@@ -156,6 +166,8 @@ def _detect_translation_patterns(train_pairs: List[Tuple[Array, Array]]) -> floa
 
 def _detect_recolor_patterns(train_pairs: List[Tuple[Array, Array]]) -> float:
     """Detect if recoloring transformations are likely."""
+    if not train_pairs:
+        return 0.0
     recolor_score = 0.0
     for inp, out in train_pairs:
         if inp.shape == out.shape:
@@ -174,6 +186,8 @@ def _detect_recolor_patterns(train_pairs: List[Tuple[Array, Array]]) -> float:
 
 def _detect_crop_patterns(train_pairs: List[Tuple[Array, Array]]) -> float:
     """Detect if cropping transformations are likely."""
+    if not train_pairs:
+        return 0.0
     crop_score = 0.0
     for inp, out in train_pairs:
         if (inp.shape[0] > out.shape[0] or inp.shape[1] > out.shape[1]):
@@ -183,6 +197,8 @@ def _detect_crop_patterns(train_pairs: List[Tuple[Array, Array]]) -> float:
 
 def _detect_pad_patterns(train_pairs: List[Tuple[Array, Array]]) -> float:
     """Detect if padding transformations are likely."""
+    if not train_pairs:
+        return 0.0
     pad_score = 0.0
     for inp, out in train_pairs:
         if (inp.shape[0] < out.shape[0] or inp.shape[1] < out.shape[1]):
@@ -225,3 +241,58 @@ def _operation_hints(features: Dict[str, Any]) -> str:
         hints.append('P')
     
     return "".join(hints) if hints else "U"  # U for unknown
+
+
+def compute_numerical_features(train_pairs: List[Tuple[Array, Array]]) -> np.ndarray:
+    """Convert task features to a numerical vector.
+
+    This utility is primarily used by learning components that expect a fixed
+    numeric representation.  The order of features is deterministic to ensure
+    reproducibility across runs.
+
+    Args:
+        train_pairs: List of training input/output grid pairs.
+
+    Returns:
+        A 1-D numpy array of feature values. Boolean features are encoded as
+        ``0.0`` or ``1.0``.
+    """
+
+    features = extract_task_features(train_pairs)
+
+    numerical_keys = [
+        'num_train_pairs',
+        'input_height_mean',
+        'input_width_mean',
+        'output_height_mean',
+        'output_width_mean',
+        'shape_preserved',
+        'size_ratio_mean',
+        'input_colors_mean',
+        'output_colors_mean',
+        'background_color_consistent',
+        'has_color_mapping',
+        'color_mapping_size',
+        'input_objects_mean',
+        'output_objects_mean',
+        'object_count_preserved',
+        'likely_rotation',
+        'likely_reflection',
+        'likely_translation',
+        'likely_recolor',
+        'likely_crop',
+        'likely_pad',
+    ]
+
+    values: List[float] = []
+    for key in numerical_keys:
+        val = features.get(key, 0)
+        if isinstance(val, bool):
+            values.append(1.0 if val else 0.0)
+        else:
+            try:
+                values.append(float(val))
+            except (TypeError, ValueError):  # pragma: no cover - defensive path
+                values.append(0.0)
+
+    return np.array(values, dtype=float)

--- a/arc_solver/guidance.py
+++ b/arc_solver/guidance.py
@@ -38,20 +38,22 @@ class SimpleClassifier:
     
     def forward(self, x: np.ndarray) -> np.ndarray:
         """Forward pass through the network."""
+        if x.ndim == 1:
+            x = x.reshape(1, -1)
         # First layer
         h = np.maximum(0, np.dot(x, self.weights1) + self.bias1)  # ReLU
         # Output layer with sigmoid
         out = 1.0 / (1.0 + np.exp(-(np.dot(h, self.weights2) + self.bias2)))
-        return out
+        return out.squeeze()
     
     def predict_operations(self, features: Dict[str, Any], threshold: float = 0.5) -> List[str]:
         """Predict which operations are likely relevant."""
         feature_vector = self._features_to_vector(features)
-        probabilities = self.forward(feature_vector)
-        
+        probabilities = self.forward(feature_vector).ravel()
+
         relevant_ops = []
         for i, prob in enumerate(probabilities):
-            if prob > threshold:
+            if float(prob) > threshold:
                 relevant_ops.append(self.operations[i])
         
         return relevant_ops if relevant_ops else ['identity']

--- a/arc_solver/memory.py
+++ b/arc_solver/memory.py
@@ -1,235 +1,366 @@
-"""
-Episodic retrieval system for ARC solver.
+"""Episodic memory and retrieval for the ARC solver.
 
-This module implements a database of previously solved programs that can be
-retrieved based on task similarity. It uses task signatures to find analogous
-tasks and reuse or adapt their solutions.
+This module implements a lightweight yet fully functional episodic memory
+system.  Previously solved tasks (episodes) are stored together with the
+programs that solved them and rich feature representations.  At inference
+time the solver can query this database for tasks with similar signatures or
+feature vectors and reuse their solutions as candidates.
+
+The implementation is intentionally deterministic and avoids any external
+dependencies so that it remains compatible with the Kaggle competition
+environment.
 """
 
 from __future__ import annotations
 
-import numpy as np
-from typing import List, Tuple, Dict, Any, Optional
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Tuple, Optional
+from collections import defaultdict
 import json
 import os
-from collections import defaultdict
+
+import numpy as np
 
 from .grid import Array
 from .features import compute_task_signature, extract_task_features
 
+# Type alias for a DSL program representation used across the project
+Program = List[Tuple[str, Dict[str, Any]]]
+
+
+@dataclass
+class Episode:
+    """Representation of a single solved ARC task.
+
+    Attributes:
+        task_signature: Canonical signature of the training pairs.
+        programs: List of successful programs for this task.
+        task_id: Optional identifier of the original task.
+        train_pairs: Training input/output pairs that produced the solution.
+        success_count: Number of times this episode led to a correct solution.
+        metadata: Additional arbitrary information.
+        features: Cached feature dictionary used for similarity comparisons.
+    """
+
+    task_signature: str
+    programs: List[Program]
+    task_id: str = ""
+    train_pairs: List[Tuple[Array, Array]] = field(default_factory=list)
+    success_count: int = 1
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    features: Dict[str, Any] = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Compute feature representation for this episode."""
+        try:
+            self.features = (
+                extract_task_features(self.train_pairs) if self.train_pairs else {}
+            )
+        except Exception as exc:  # pragma: no cover - defensive programming
+            raise ValueError(f"invalid training pairs for episode: {exc}") from exc
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise the episode to a plain Python dictionary."""
+        return {
+            "task_signature": self.task_signature,
+            "programs": [
+                [(op, params) for op, params in program]
+                for program in self.programs
+            ],
+            "task_id": self.task_id,
+            "train_pairs": [
+                (inp.tolist(), out.tolist()) for inp, out in self.train_pairs
+            ],
+            "success_count": self.success_count,
+            "metadata": self.metadata,
+            "features": self.features,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Episode":
+        """Reconstruct an :class:`Episode` from a dictionary."""
+        train_pairs = [
+            (np.array(inp, dtype=int), np.array(out, dtype=int))
+            for inp, out in data.get("train_pairs", [])
+        ]
+        episode = cls(
+            task_signature=data["task_signature"],
+            programs=[
+                [(op, params) for op, params in program]
+                for program in data.get("programs", [])
+            ],
+            task_id=data.get("task_id", ""),
+            train_pairs=train_pairs,
+            success_count=data.get("success_count", 1),
+            metadata=data.get("metadata", {}),
+        )
+        # If features were stored, reuse them to avoid recomputation
+        if "features" in data:
+            episode.features = data["features"]
+        return episode
+
 
 class EpisodeDatabase:
-    """Database of solved ARC tasks with episodic retrieval capability."""
-    
-    def __init__(self, db_path: Optional[str] = None):
-        self.episodes: List[Dict[str, Any]] = []
+    """Persistent store for :class:`Episode` objects."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.episodes: Dict[int, Episode] = {}
         self.signature_index: Dict[str, List[int]] = defaultdict(list)
+        self.program_index: Dict[str, List[int]] = defaultdict(list)
         self.db_path = db_path
-        
-        if db_path and os.path.exists(db_path):
-            self.load_database()
-    
-    def add_episode(self, train_pairs: List[Tuple[Array, Array]], 
-                   successful_programs: List[List[Tuple[str, Dict[str, Any]]]], 
-                   task_id: str = ""):
-        """Add a solved task to the episode database."""
-        signature = compute_task_signature(train_pairs)
-        features = extract_task_features(train_pairs)
-        
-        episode = {
-            'task_id': task_id,
-            'signature': signature,
-            'features': features,
-            'train_pairs': [(inp.tolist(), out.tolist()) for inp, out in train_pairs],
-            'successful_programs': successful_programs,
-            'difficulty': self._estimate_difficulty(features),
-            'solution_count': len(successful_programs),
-        }
-        
-        episode_idx = len(self.episodes)
-        self.episodes.append(episode)
-        self.signature_index[signature].append(episode_idx)
-    
-    def retrieve_similar_episodes(self, train_pairs: List[Tuple[Array, Array]], 
-                                 k: int = 5) -> List[Dict[str, Any]]:
-        """Retrieve k most similar episodes to the given task."""
-        query_signature = compute_task_signature(train_pairs)
-        query_features = extract_task_features(train_pairs)
-        
-        # First, try exact signature match
-        exact_matches = []
-        if query_signature in self.signature_index:
-            for idx in self.signature_index[query_signature]:
-                exact_matches.append(self.episodes[idx])
-        
-        if exact_matches:
-            return exact_matches[:k]
-        
-        # If no exact matches, compute similarity scores
-        similarities = []
-        for episode in self.episodes:
-            similarity = self._compute_similarity(query_features, episode['features'])
-            similarities.append((similarity, episode))
-        
-        # Sort by similarity and return top k
-        similarities.sort(key=lambda x: x[0], reverse=True)
-        return [episode for _, episode in similarities[:k]]
-    
-    def get_candidate_programs(self, train_pairs: List[Tuple[Array, Array]], 
-                              max_programs: int = 10) -> List[List[Tuple[str, Dict[str, Any]]]]:
-        """Get candidate programs from similar episodes."""
-        similar_episodes = self.retrieve_similar_episodes(train_pairs)
-        
-        candidate_programs = []
-        for episode in similar_episodes:
-            for program in episode['successful_programs']:
-                candidate_programs.append(program)
-                if len(candidate_programs) >= max_programs:
-                    break
-            if len(candidate_programs) >= max_programs:
-                break
-        
-        return candidate_programs
-    
-    def _compute_similarity(self, features1: Dict[str, Any], features2: Dict[str, Any]) -> float:
-        """Compute similarity between two feature vectors."""
-        # Simple cosine similarity on numerical features
-        numerical_keys = [
-            'num_train_pairs', 'input_height_mean', 'input_width_mean',
-            'output_height_mean', 'output_width_mean', 'size_ratio_mean',
-            'input_colors_mean', 'output_colors_mean', 'color_mapping_size',
-            'input_objects_mean', 'output_objects_mean', 'object_count_preserved',
-            'likely_rotation', 'likely_reflection', 'likely_translation',
-            'likely_recolor', 'likely_crop', 'likely_pad'
+        self._next_id = 1
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _program_key(program: Program) -> str:
+        """Create a hashable key for a program.
+
+        Parameters are sorted to guarantee determinism.
+        """
+        normalised = [
+            (op, tuple(sorted(params.items()))) for op, params in program
         ]
-        
-        v1 = np.array([features1.get(k, 0) for k in numerical_keys])
-        v2 = np.array([features2.get(k, 0) for k in numerical_keys])
-        
-        # Normalize vectors
+        return json.dumps(normalised)
+
+    def _compute_similarity(self, f1: Dict[str, Any], f2: Dict[str, Any]) -> float:
+        """Compute cosine similarity between two feature dictionaries."""
+        numerical_keys = [
+            "num_train_pairs",
+            "input_height_mean",
+            "input_width_mean",
+            "output_height_mean",
+            "output_width_mean",
+            "size_ratio_mean",
+            "input_colors_mean",
+            "output_colors_mean",
+            "color_mapping_size",
+            "input_objects_mean",
+            "output_objects_mean",
+            "object_count_preserved",
+            "likely_rotation",
+            "likely_reflection",
+            "likely_translation",
+            "likely_recolor",
+            "likely_crop",
+            "likely_pad",
+        ]
+
+        v1 = np.array([float(f1.get(k, 0.0)) for k in numerical_keys])
+        v2 = np.array([float(f2.get(k, 0.0)) for k in numerical_keys])
+
         norm1 = np.linalg.norm(v1)
         norm2 = np.linalg.norm(v2)
-        
         if norm1 == 0 or norm2 == 0:
             return 0.0
-        
-        cosine_sim = np.dot(v1, v2) / (norm1 * norm2)
-        
-        # Add bonus for boolean feature matches
-        boolean_keys = ['shape_preserved', 'background_color_consistent', 'has_color_mapping']
-        boolean_matches = sum(1 for k in boolean_keys if features1.get(k, False) == features2.get(k, False))
-        boolean_bonus = boolean_matches / len(boolean_keys) * 0.2
-        
-        return cosine_sim + boolean_bonus
-    
-    def _estimate_difficulty(self, features: Dict[str, Any]) -> float:
-        """Estimate task difficulty based on features."""
-        difficulty = 0.0
-        
-        # More training pairs might indicate harder task
-        difficulty += features.get('num_train_pairs', 0) * 0.1
-        
-        # Larger grids are typically harder
-        grid_size = features.get('input_height_mean', 0) * features.get('input_width_mean', 0)
-        difficulty += grid_size / 1000.0
-        
-        # More colors and objects increase difficulty
-        difficulty += features.get('input_colors_mean', 0) * 0.1
-        difficulty += features.get('input_objects_mean', 0) * 0.05
-        
-        # Shape changes increase difficulty
-        if not features.get('shape_preserved', True):
-            difficulty += 0.5
-        
-        return min(difficulty, 1.0)  # Cap at 1.0
-    
-    def save_database(self, filepath: Optional[str] = None):
-        """Save the episode database to file."""
+
+        cosine_sim = float(np.dot(v1, v2) / (norm1 * norm2))
+
+        # Add a small bonus for matching boolean properties
+        boolean_keys = [
+            "shape_preserved",
+            "background_color_consistent",
+            "has_color_mapping",
+        ]
+        matches = sum(
+            1
+            for k in boolean_keys
+            if bool(f1.get(k, False)) == bool(f2.get(k, False))
+        )
+        cosine_sim += matches / len(boolean_keys) * 0.2
+        return min(cosine_sim, 1.0)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def store_episode(
+        self,
+        task_signature: str,
+        programs: List[Program],
+        task_id: str,
+        train_pairs: List[Tuple[Array, Array]],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> int:
+        """Store a solved episode and return its identifier."""
+
+        episode = Episode(
+            task_signature=task_signature,
+            programs=programs,
+            task_id=task_id,
+            train_pairs=train_pairs,
+            metadata=metadata or {},
+        )
+
+        episode_id = self._next_id
+        self._next_id += 1
+
+        self.episodes[episode_id] = episode
+        self.signature_index[task_signature].append(episode_id)
+        for program in programs:
+            key = self._program_key(program)
+            self.program_index[key].append(episode_id)
+
+        return episode_id
+
+    def get_episode(self, episode_id: int) -> Optional[Episode]:
+        """Retrieve an episode by its identifier."""
+        return self.episodes.get(episode_id)
+
+    def query_by_signature(self, signature: str) -> List[Episode]:
+        """Return all episodes with the given task signature."""
+        ids = self.signature_index.get(signature, [])
+        return [self.episodes[i] for i in ids]
+
+    def query_by_similarity(
+        self,
+        train_pairs: List[Tuple[Array, Array]],
+        similarity_threshold: float = 0.5,
+        max_results: int = 5,
+    ) -> List[Tuple[Episode, float]]:
+        """Return episodes whose feature similarity exceeds the threshold."""
+
+        if not train_pairs:
+            return []
+        query_features = extract_task_features(train_pairs)
+        results: List[Tuple[Episode, float]] = []
+        for episode in self.episodes.values():
+            similarity = self._compute_similarity(query_features, episode.features)
+            if similarity >= similarity_threshold:
+                results.append((episode, similarity))
+
+        results.sort(key=lambda x: x[1], reverse=True)
+        return results[:max_results]
+
+    def get_candidate_programs(
+        self, train_pairs: List[Tuple[Array, Array]], max_programs: int = 10
+    ) -> List[Program]:
+        """Return programs from similar episodes for reuse."""
+        candidates: List[Program] = []
+        for episode, _ in self.query_by_similarity(train_pairs, 0.0, max_programs):
+            for program in episode.programs:
+                candidates.append(program)
+                if len(candidates) >= max_programs:
+                    return candidates
+        return candidates
+
+    def remove_episode(self, episode_id: int) -> None:
+        """Remove an episode from the database."""
+        episode = self.episodes.pop(episode_id, None)
+        if not episode:
+            return
+        self.signature_index[episode.task_signature] = [
+            i for i in self.signature_index[episode.task_signature] if i != episode_id
+        ]
+        for program in episode.programs:
+            key = self._program_key(program)
+            self.program_index[key] = [
+                i for i in self.program_index[key] if i != episode_id
+            ]
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+    def save(self, filepath: Optional[str] = None) -> None:
+        """Persist database to a JSON file."""
         save_path = filepath or self.db_path
         if not save_path:
             return
-        
-        try:
-            with open(save_path, 'w') as f:
-                json.dump(self.episodes, f, indent=2)
-        except Exception as e:
-            print(f"Failed to save database: {e}")
-    
-    def load_database(self, filepath: Optional[str] = None):
-        """Load the episode database from file."""
+        data = {
+            "next_id": self._next_id,
+            "episodes": {str(eid): ep.to_dict() for eid, ep in self.episodes.items()},
+        }
+        with open(save_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+
+    def load(self, filepath: Optional[str] = None) -> None:
+        """Load database from a JSON file."""
         load_path = filepath or self.db_path
         if not load_path or not os.path.exists(load_path):
             return
-        
         try:
-            with open(load_path, 'r') as f:
-                self.episodes = json.load(f)
-            
-            # Rebuild signature index
-            self.signature_index = defaultdict(list)
-            for idx, episode in enumerate(self.episodes):
-                signature = episode['signature']
-                self.signature_index[signature].append(idx)
-                
-        except Exception as e:
-            print(f"Failed to load database: {e}")
-            self.episodes = []
-            self.signature_index = defaultdict(list)
-    
+            with open(load_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except json.JSONDecodeError:
+            return  # Treat malformed file as empty database
+
+        self._next_id = int(data.get("next_id", 1))
+        self.episodes = {
+            int(eid): Episode.from_dict(ep_data)
+            for eid, ep_data in data.get("episodes", {}).items()
+        }
+
+        # Rebuild indexes deterministically
+        self.signature_index.clear()
+        self.program_index.clear()
+        for eid, episode in self.episodes.items():
+            self.signature_index[episode.task_signature].append(eid)
+            for program in episode.programs:
+                key = self._program_key(program)
+                self.program_index[key].append(eid)
+
+    # ------------------------------------------------------------------
+    # Statistics
+    # ------------------------------------------------------------------
     def get_statistics(self) -> Dict[str, Any]:
-        """Get database statistics."""
-        if not self.episodes:
-            return {}
-        
-        difficulties = [ep['difficulty'] for ep in self.episodes]
-        solution_counts = [ep['solution_count'] for ep in self.episodes]
-        
+        """Return basic database statistics."""
+        total_episodes = len(self.episodes)
+        total_programs = sum(len(ep.programs) for ep in self.episodes.values())
+        avg_programs = (
+            float(total_programs) / total_episodes if total_episodes else 0.0
+        )
         return {
-            'total_episodes': len(self.episodes),
-            'unique_signatures': len(self.signature_index),
-            'avg_difficulty': np.mean(difficulties),
-            'avg_solutions_per_task': np.mean(solution_counts),
-            'max_solutions_per_task': max(solution_counts),
+            "total_episodes": total_episodes,
+            "unique_signatures": len(self.signature_index),
+            "total_programs": total_programs,
+            "average_programs_per_episode": avg_programs,
         }
 
 
 class EpisodicRetrieval:
-    """Main interface for episodic retrieval in the ARC solver."""
-    
-    def __init__(self, db_path: str = "episodes.json"):
+    """High-level interface used by the solver to access episodic memory."""
+
+    def __init__(self, db_path: str = "episodes.json") -> None:
         self.database = EpisodeDatabase(db_path)
-        self.cache = {}  # Simple cache for recent queries
-    
-    def query_for_programs(self, train_pairs: List[Tuple[Array, Array]], 
-                          max_candidates: int = 5) -> List[List[Tuple[str, Dict[str, Any]]]]:
-        """Query the database for candidate programs."""
-        # Check cache first
+        self.cache: Dict[str, List[Program]] = {}
+
+    def query_for_programs(
+        self, train_pairs: List[Tuple[Array, Array]], max_candidates: int = 5
+    ) -> List[Program]:
+        """Return candidate programs similar to the given training pairs."""
+
+        if not train_pairs:
+            return []
         cache_key = compute_task_signature(train_pairs)
         if cache_key in self.cache:
             return self.cache[cache_key]
-        
+
         candidates = self.database.get_candidate_programs(train_pairs, max_candidates)
-        
-        # Cache result
         self.cache[cache_key] = candidates
-        if len(self.cache) > 100:  # Simple cache eviction
+        if len(self.cache) > 100:
             self.cache.clear()
-        
         return candidates
-    
-    def add_successful_solution(self, train_pairs: List[Tuple[Array, Array]], 
-                               programs: List[List[Tuple[str, Dict[str, Any]]]], 
-                               task_id: str = ""):
-        """Add a successful solution to the database."""
-        self.database.add_episode(train_pairs, programs, task_id)
-        
-        # Clear cache since database changed
+
+    def add_successful_solution(
+        self,
+        train_pairs: List[Tuple[Array, Array]],
+        programs: List[Program],
+        task_id: str = "",
+    ) -> None:
+        """Store a successful solution in the episodic database."""
+
+        signature = compute_task_signature(train_pairs)
+        self.database.store_episode(signature, programs, task_id, train_pairs)
         self.cache.clear()
-    
-    def save(self):
-        """Save the database."""
-        self.database.save_database()
-    
+
+    def save(self) -> None:
+        """Persist the underlying database."""
+        self.database.save()
+
     def get_stats(self) -> Dict[str, Any]:
-        """Get retrieval statistics."""
+        """Return statistics about the episodic database."""
         return self.database.get_statistics()
+


### PR DESCRIPTION
## Summary
- Extend feature extraction to handle raw grids safely and expose a deterministic numerical feature vector
- Add a fully-fledged episodic memory with serialisable `Episode` objects and similarity queries
- Harden neural guidance and solver fallbacks for reliable operation

## Testing
- `pytest tests/test_features.py tests/test_memory.py tests/test_dsl_ops.py tests/test_dsl_cache.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1dfadb4908322bca8bbca6eab0e91