### PR TITLE
Handle MemoryError in submission pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -495,6 +495,11 @@ class MetaCognition:
     Notes: Episode loader and DSL cast dy/dx/fill and mapping entries to int
 
 
+[X] Step 4.3 UPDATE4 - Submission script handles memory errors with fallback
+    Date: 2025-09-13
+    Test Result: pytest tests/test_solve_with_budget_memory.py -q
+    Notes: solve_with_budget catches MemoryError, reports memerror count, runs gc per task
+
 
 ```
 

--- a/tests/test_solve_with_budget_memory.py
+++ b/tests/test_solve_with_budget_memory.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from arc_submit import solve_with_budget
+
+class DummySolver:
+    def solve_task_two_attempts(self, task):
+        raise MemoryError("boom")
+
+    def best_so_far(self, task):
+        return [[0]]
+
+def test_memory_error_fallback():
+    attempts, meta = solve_with_budget({}, DummySolver())
+    assert attempts[0]["output"] == [[0]]
+    assert meta["memerror"] is True
+    assert meta["timeout"] is False


### PR DESCRIPTION
## Summary
- catch MemoryError in `solve_with_budget` and fall back to best-so-far prediction
- track per-task memory failures and run `gc.collect()` to free resources
- add regression test exercising MemoryError path and document progress marker

## Testing
- `python -m py_compile arc_submit.py`
- `pytest tests/test_solve_with_budget_memory.py -q`
- `pytest test_beam_search_fix.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5048f2e18832297e8b1c0856171a5