### PR TITLE
docs: add RFT behavioral profile and image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,10 @@ Record completion as:
     Date: 2025-09-14
     Test Result: pytest tests/test_canonical.py -q
     Notes: Property-based invariance checks for D4 symmetries and colour relabeling
+[X] Docs: Behavioral RFT profile added
+    Date: 2025-09-14
+    Test Result: pytest -q
+    Notes: Added repository profile with RFT focus and public image
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 This repository contains an advanced solver for the **ARC Prize 2025** competition (ARC‑AGI‑2), implementing the complete blueprint from neuroscience-inspired research. It combines symbolic reasoning with neural guidance, episodic retrieval, program sketches, and test-time training to achieve superior performance on abstract reasoning tasks.
 
+## Behavioral Approach with Relational Frame Theory
+
+<p align="center">
+  <img src="docs/images/rft_behavioral_approach.svg" alt="Behavioral RFT approach" width="400"/>
+</p>
+
+We are exploring a behavioral perspective grounded in **Relational Frame Theory (RFT)** to tackle ARC. RFT models language and cognition as networks of learned relational frames, giving us a principled way to compose and generalize transformations across tasks.
+
+For more details, see [profile/README.md](profile/README.md).
+
 ## Key Features
 
 ### 🧠 Neuroscience-Inspired Architecture

--- a/docs/images/rft_behavioral_approach.svg
+++ b/docs/images/rft_behavioral_approach.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="400" height="200" fill="#f0f0f0"/>
+  <text x="200" y="100" font-size="20" text-anchor="middle" fill="#333">Behavioral RFT Approach</text>
+</svg>

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,10 @@
+# Behavioral RFT Profile
+
+We pursue a behavioral approach to the Abstraction and Reasoning Corpus (ARC) grounded in **Relational Frame Theory (RFT)**. RFT views language and cognition as patterns of learned relations, offering a framework for flexible transformation and generalization.
+
+![Behavioral RFT approach](../docs/images/rft_behavioral_approach.svg)
+
+## Public Description
+Our exploration maps ARC transformations through relational frames, aiming for adaptive, rule-based solutions that emerge from behavioral principles rather than brute-force search alone.
+
+[S:DOC v1] profile_behavioral_rft pass

--- a/tests/test_profile_image.py
+++ b/tests/test_profile_image.py
@@ -1,0 +1,9 @@
+# [S:TEST v1] profile image exists and contains title pass
+from pathlib import Path
+
+
+def test_profile_image_exists_and_has_text():
+    img_path = Path('docs/images/rft_behavioral_approach.svg')
+    assert img_path.is_file(), 'profile image missing'
+    content = img_path.read_text(encoding='utf-8')
+    assert '<svg' in content and 'Behavioral RFT Approach' in content


### PR DESCRIPTION
## Summary
- add behavioral RFT profile README with illustrative SVG
- highlight new RFT approach in main README
- test profile image presence and update progress ledger

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for arc_solver.enhanced_solver and scipy)*
- `pytest tests/test_profile_image.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6a9fd552483229909c29e8d259105