### PR TITLE
docs: publish architecting abstraction blueprint

### DIFF
--- a/PUMA ARC 2025/Architecting_Abstraction.md
+++ b/PUMA ARC 2025/Architecting_Abstraction.md
@@ -1,0 +1,468 @@
+[S:DESIGN v1] artifact=architecting_abstraction treatise=library_architecture pass
+[S:DOC v1] coverage=libraries_and_rft_dsl status=published pass
+
+# Architecting Abstraction: A Blueprint for Building Robust, Large-Scale Libraries and Domain-Specific Languages
+
+## Part I: Architectural Foundations for Large-Scale Libraries
+This foundational part establishes the universal principles required to manage the inherent complexity of any large-scale software library. It synthesizes best practices from software architecture, API design, and Python-specific project structuring to create a robust framework for the blueprints that follow.
+
+### Chapter 1: Taming Complexity - Architectural Patterns for Monolithic Libraries
+#### 1.1. Introduction: The Monolith as a Deliberate Choice
+In an era where distributed systems and microservices dominate architectural discourse, proposing a monolithic architecture may seem counterintuitive. However, for a software library—a component designed to be consumed as a single, cohesive unit—a monolithic structure is not only appropriate but often the most effective choice. A library is, by definition, a single deployable artifact. The challenge, therefore, is not to avoid the monolith but to impose a rigorous internal structure that prevents it from degrading into an unmaintainable "big ball of mud".
+
+The primary architectural goal for a large-scale library is to manage internal complexity through disciplined modularity and clear separation of concerns. While the library is deployed as one unit, its internal design should reflect the principles of modern, decoupled systems. This involves adapting architectural patterns typically associated with distributed applications to an in-process context. The most effective architecture for a large, monolithic library is a hybrid approach that synthesizes the principles of established patterns. The core problem these patterns solve—managing complexity, ensuring scalability, and enabling parallel development—is identical to the challenges faced within a large library's codebase. The critical distinction is that the boundaries between components must be enforced through logical contracts and programming discipline rather than the physical separation of network calls.
+
+#### 1.2. The Layered Architecture Pattern
+The Layered Architecture, or n-tier architecture, is one of the most fundamental and widely used patterns for achieving separation of concerns. In this pattern, the system is decomposed into horizontal layers, each with a specific responsibility. A key constraint is that a layer should only communicate with the layer directly beneath it, which simplifies dependencies and promotes maintainability.
+
+For a software library, this pattern can be adapted from its typical application in enterprise systems:
+
+- **Public API Layer (Presentation Layer):** This is the outermost layer and the sole entry point for the library's users. It defines the public-facing functions, classes, and methods. Its responsibility is to validate user input and delegate calls to the layer below. Crucially, this layer should contain no business logic; its purpose is to be a clean, stable interface.
+- **Core Logic Layer (Business Logic Layer):** This layer contains the core algorithms, business rules, and domain-specific logic that constitute the library's primary functionality. It is completely decoupled from the public API, meaning it could theoretically be exposed through a different API (e.g., a command-line interface or a different set of functions) without modification. This is where the main intellectual property of the library resides.
+- **Utilities & Data Layer (Data Access Layer):** This is the lowest-level layer, providing foundational services to the layers above. It includes internal data structures, helper functions, interactions with the filesystem or network, and any other cross-cutting concerns. By isolating these utilities, the core logic remains focused on its domain, and common functionalities are not duplicated.
+
+This layered approach provides a clear and organized structure, making the system easier to test, debug, and maintain. However, if not designed with care, it can introduce performance overhead or become overly rigid, making it difficult to adapt to future requirements.
+
+#### 1.3. Domain-Driven Design (DDD) for Libraries
+Domain-Driven Design (DDD) is a software design philosophy that emphasizes modeling the software around the business domain it represents. For a large library, DDD provides a powerful toolkit for managing complexity by aligning the internal structure with the library's core purpose. Two DDD concepts are particularly vital for library architecture:
+
+- **Bounded Contexts:** A bounded context is a clear boundary within which a particular domain model is defined and consistent. In a large library with a 1,000-function surface, it is likely that several distinct sub-domains exist. For example, a data analysis library might have separate bounded contexts for data ingestion, transformation, statistical modeling, and visualization. Each context should be implemented as a distinct package or a set of modules with well-defined interfaces. This partitioning allows different parts of the library to evolve independently and prevents the conceptual models of different domains from becoming entangled.
+- **Ubiquitous Language:** DDD advocates for the development of a common, shared language (the "ubiquitous language") that is used by developers, domain experts, and even in the code itself. For a library, this means that the names of classes, methods, and parameters in the public API should directly correspond to the concepts of the problem domain. This ensures conceptual integrity from the user's perspective all the way down to the implementation, making the library more intuitive and its documentation clearer.
+
+#### 1.4. Adapting Microservice Principles to a Monolithic Context
+While a library is not a collection of distributed microservices, the principles that make microservice architectures successful can be applied internally to achieve similar benefits of modularity and maintainability. The fundamental principle of microservices is not the network call itself, but the strong encapsulation of a business capability behind a stable, well-defined interface.
+
+This principle can be directly translated to the internal structure of a monolithic library:
+
+- **Modules as Services:** Each bounded context or major functional area of the library should be treated as an internal "service." These modules should be highly cohesive, containing all the logic related to their specific capability.
+- **Internal APIs:** Communication between these internal modules should occur only through stable, public functions and classes defined in their `__init__.py` files or specific interface modules. Direct access to internal implementation details of another module should be strictly forbidden. This practice of "programming to an interface, not an implementation" ensures loose coupling.
+- **Module Autonomy:** Designing modules this way allows them to be developed, tested, and refactored with a degree of autonomy, much like a microservice team can operate independently. As long as the internal API contract is maintained, changes within one module will not cascade and break other parts of the library. This approach achieves the organizational benefits of microservices—scalability of development, fault isolation (at a logical level), and maintainability—without incurring the significant operational overhead of a distributed system.
+
+### Chapter 2: The Art of the API - Principles of Modern Library Design
+The Application Programming Interface (API) is the library's user interface. For a library with a large surface area, a well-designed API is not a luxury but a necessity for adoption and long-term success.
+
+#### 2.1. Designing for the Naive User
+The most critical principle of API design is empathy for the user. The API should be designed from the perspective of a developer who is new to the library, following the Principle of Least Surprise. This means that the behavior of a function should be what a user would naturally expect. The design process must begin not with the implementation details but with how the user will interact with the library. This involves prototyping usage examples, writing tests first, and playing with the API to ensure it feels intuitive before committing to an internal structure.
+
+#### 2.2. Consistency as the Cornerstone
+With an API surface of 1,000 functions, consistency is the single most important factor in creating a usable and learnable library. Inconsistency forces users to constantly refer to documentation and increases their cognitive load. A consistent API governance strategy must be established and enforced, covering:
+
+- **Naming Conventions:** Resource names should be nouns (e.g., `get_orders`), and collections should be plural (e.g., `/customers/5/orders`). Methods that perform actions can be verbs. The chosen convention must be applied universally.
+- **Parameter Ordering:** The order of parameters in similar functions should be consistent. For example, if multiple functions take a source and destination, they should always appear in the same order.
+- **Return Values:** Functions that can fail should have a consistent way of signaling errors (e.g., raising exceptions rather than returning `None` or error codes). Functions that succeed should return consistent types.
+- **Behavioral Patterns:** Common operations should behave identically across the API. For example, if some `add` methods mutate an object in place while others return a new object, it will lead to confusion and bugs.
+
+#### 2.3. Robust Error Handling Strategy
+A library's error handling strategy is a critical part of its API contract. A poor strategy can make the library difficult to debug and unreliable in production.
+
+- **Custom Exception Hierarchy:** The library should define its own base exception class. All custom exceptions thrown by the library should inherit from this base class. This allows users to write a single `except MyLibraryError:` block to catch any error originating from the library, without accidentally catching unrelated exceptions from Python or other libraries.
+- **Clear and Actionable Messages:** Error messages are part of the user experience. They should be written in plain language, avoiding technical jargon. A good error message clearly states what went wrong, why it went wrong, and what the user can do to fix it.
+- **Layered Error Handling:** It is important to distinguish between different types of errors. Domain errors (e.g., `InvalidUserInputError`) are part of the expected behavior and should be documented as part of the public API. Infrastructure or internal errors (e.g., a failure to read an internal configuration file) should be caught and either handled gracefully or wrapped in a more generic library exception to avoid leaking implementation details to the user.
+
+#### 2.4. Performance and Optimization
+While correctness and usability are paramount, performance is a key consideration for any large library. The approach to optimization must be disciplined and data-driven.
+
+- **Profile Before Optimizing:** Premature optimization is a common anti-pattern. Performance tuning should begin only after identifying real-world bottlenecks using profiling tools like Python's built-in `cProfile` module or third-party tools like Py-Spy. The focus should be on the "hot spots" in the code that consume the most time.
+- **Algorithmic and Data Structure Efficiency:** The most significant performance gains often come from choosing the right algorithm and data structure for the task. For example, using a set for membership testing (O(1) average time complexity) is vastly more efficient than searching a list (O(n) time complexity).
+- **Lazy Loading and Caching:** For operations that are computationally expensive or involve heavy I/O, lazy loading should be employed. This means deferring the operation until the result is actually needed. For functions that are called repeatedly with the same arguments, caching the results using decorators like `functools.lru_cache` can provide a dramatic performance boost with minimal code changes.
+
+### Chapter 3: Pythonic Structure at Scale
+The physical layout of the project on the filesystem and the logical structure of its modules and packages are foundational to its maintainability and scalability.
+
+#### 3.1. Recommended Project Layout
+A standardized and predictable directory structure is essential for navigating a large codebase. The following layout is based on modern Python best practices and clearly separates concerns:
+
+```
+my_awesome_library/
+├── docs/                # Documentation files (Sphinx)
+│   ├── conf.py
+│   └── index.rst
+├── my_awesome_library/  # The actual library source code (package)
+│   ├── __init__.py
+│   ├── core/            # Core logic, domain models
+│   │   ├── __init__.py
+│   │   └──...
+│   ├── api/             # Public-facing API modules
+│   │   ├── __init__.py
+│   │   └──...
+│   ├── utils/           # Internal utilities
+│   │   ├── __init__.py
+│   │   └──...
+│   └── exceptions.py    # Custom exception classes
+├── tests/               # Test suite
+│   ├── __init__.py
+│   ├── unit/            # Unit tests for individual components
+│   └── integration/     # Tests for interactions between components
+├── .gitignore
+├── LICENSE
+├── pyproject.toml       # Modern package metadata and dependencies
+└── README.md
+```
+
+This structure places the library's source code within a dedicated package directory (`my_awesome_library/my_awesome_library/`), which is a clean pattern that avoids namespace conflicts. It provides distinct top-level directories for documentation and tests, making the project's organization immediately clear to new contributors.
+
+#### 3.2. The Role of `__init__.py`
+In a large package, `__init__.py` files serve a dual purpose. While it is good practice to keep them minimal to avoid executing complex logic upon import, they are instrumental in defining a package's public API.
+
+A strategic use of `__init__.py` is to explicitly import the symbols (classes, functions) from sub-modules that are intended to be part of the public interface. For example, `my_awesome_library/api/__init__.py` might contain:
+
+```python
+from .users import get_user, create_user
+from .products import list_products
+
+__all__ = ["get_user", "create_user", "list_products"]
+```
+
+This allows users to import these functions directly from `my_awesome_library.api` instead of needing to know the internal module structure. The `__all__` variable further clarifies the public API, affecting the behavior of `from my_awesome_library.api import *`.
+
+#### 3.3. Managing Dependencies and Avoiding Circular Imports
+As a project grows, the risk of creating circular dependencies between modules increases significantly. This occurs when module A imports module B, and module B in turn imports module A. This is a sign of poor architectural structure and will cause `ImportError` exceptions at runtime.
+
+The solution is to design the module dependencies as a Directed Acyclic Graph (DAG). This is achieved by adhering to the layered architecture described earlier:
+
+- Define clear layers of responsibility (e.g., utils -> core -> api).
+- Enforce a strict rule: a module in a higher layer can import from a module in a lower layer, but never the other way around.
+- For example, api modules can import from core and utils, and core modules can import from utils, but utils modules must not import from core or api.
+
+This discipline prevents circular dependencies and results in a more understandable and maintainable codebase.
+
+#### 3.4. Case Study - Architectural Deep Dive into pandas and Django
+Examining successful, large-scale open-source Python libraries provides invaluable lessons in architectural design.
+
+- **Pandas:** The pandas library is a cornerstone of the Python data science ecosystem. Its architecture is a masterclass in performance optimization and handling complex, heterogeneous data. At its heart is the `BlockManager`, an internal component that is not part of the public API. The `BlockManager` groups columns of a `DataFrame` by their data type (e.g., all `float64` columns together, all `int64` columns together) into contiguous blocks of memory managed by NumPy arrays. This columnar organization provides significant performance benefits for vectorized operations, which are common in data analysis. The architecture also demonstrates a pragmatic separation of concerns: the core data structures are implemented in Python for flexibility, while performance-critical algorithms are written in Cython or C to achieve near-native speed. This hybrid approach is a key lesson for any library where performance is a critical requirement.
+- **Django:** The Django web framework is a premier example of a well-structured, large-scale Python project that champions separation of concerns through its Model-View-Template (MVT) architecture.
+  - **Model:** Represents the data structure and logic, acting as an abstraction layer over the database through its Object-Relational Mapper (ORM).
+  - **View:** Handles the business logic. It receives an HTTP request, interacts with the models to fetch or manipulate data, and then passes that data to a template for rendering.
+  - **Template:** The presentation layer, responsible for rendering the final HTML output. It is deliberately limited in its logical capabilities to enforce a clean separation from the view's business logic.
+
+This "shared-nothing" architecture, where each component is independent and can be replaced, is a powerful pattern. For a non-web library, the MVT principles can be adapted: Model corresponds to the library's internal data structures, View corresponds to the core processing functions that operate on those structures, and Template could represent different output formatters (e.g., JSON, XML, plain text) that present the results of the processing.
+
+## Part II: Blueprint for a General-Purpose Library with 1,000 Functions & Chains
+This part provides a concrete blueprint for the first requested library, focusing on the strategic choice and implementation of a Domain-Specific Language to manage its large and chainable API.
+
+### Chapter 4: The DSL Decision - Internal vs. External Languages
+#### 4.1. What is a Domain-Specific Language (DSL)?
+A Domain-Specific Language (DSL) is a computer language specialized for a particular application domain. Unlike a General-Purpose Language (GPL) like Python, which is broadly applicable, a DSL is designed with constructs that exactly fit a specific problem space. For example, SQL is a DSL for database queries, and CSS is a DSL for styling web documents. The primary goal of a DSL is to improve productivity and communication by allowing solutions to be expressed in the idiom and at the level of abstraction of the problem domain itself.
+
+When designing a library with a vast and expressive API, the creators are effectively designing a language for interacting with their domain. The choice is whether to embed this language within Python (an internal DSL) or to create a new, separate language (an external DSL).
+
+#### 4.2. Internal (Embedded) DSLs
+An internal DSL, also known as an embedded DSL or a fluent interface, is not a new language but rather a particular style of programming within a host language that gives the code a more expressive, language-like feel. It is implemented as a library that leverages the syntax and features of the host language.
+
+- **Pros:**
+  - Lower Implementation Cost: There is no need to build a custom parser, compiler, or interpreter. The DSL is processed by the host language's existing toolchain.
+  - Seamless Integration: The DSL code is just regular host language code, allowing for easy interoperability with other libraries and language features.
+  - Familiar Tooling: Developers can use their existing IDEs, debuggers, and profilers without any special configuration.
+  - Gentle Learning Curve: For developers already proficient in the host language, learning the DSL is a matter of learning a new library API, not an entirely new language.
+- **Cons:**
+  - Syntactic Constraints: The DSL is limited by the syntax of the host language. This can lead to "syntactic noise"—extraneous characters like parentheses and dots that are required by the host language but not by the domain's logic.
+  - Less Accessible to Non-Programmers: Because it is still fundamentally code in a GPL, it can be difficult for non-technical domain experts to read or write.
+
+#### 4.3. External DSLs
+An external DSL is a standalone language with its own custom syntax, grammar, and semantics. It is parsed independently of any host language.
+
+- **Pros:**
+  - Complete Syntactic Freedom: The language can be designed to be perfectly expressive for its domain, free from the constraints of a host language. The syntax can be tailored to be highly readable, even for non-programmers.
+  - Enhanced Validation: The parser can enforce complex, domain-specific rules and provide highly specific error messages that would be difficult to implement in an internal DSL.
+  - Platform Independence: An external DSL can be used to generate code or configurations for multiple different platforms or languages from a single source.
+- **Cons:**
+  - High Implementation Cost: Creating an external DSL is a significant undertaking. It requires designing a grammar and building a lexer, parser, and either an interpreter or a code generator.
+  - Requires Dedicated Tooling: To provide a good developer experience, an external DSL needs its own tools, such as syntax highlighting, code completion, and debuggers. This often requires implementing a Language Server Protocol (LSP) server.
+  - Steeper Learning Curve: Users must learn an entirely new language, which can be a barrier to adoption.
+
+**Table 1: Comparison of Internal vs. External DSL Approaches**
+
+The decision between an internal and external DSL is a critical architectural trade-off. For a library intended primarily for use by Python developers, an internal DSL often strikes the right balance. It provides the desired expressiveness and chainability while minimizing the implementation burden and adoption friction.
+
+| Feature | Internal DSL (Fluent API) | External DSL (Custom Language) |
+| --- | --- | --- |
+| Syntax | Limited by host language (e.g., Python) | Fully customizable, highly expressive |
+| Implementation Cost | Low (implemented as a library) | High (requires lexer, parser, etc.) |
+| Tooling | Inherits from host language (IDE, debugger) | Requires custom tooling (LSP, etc.) |
+| Target Audience | Developers | Developers and non-technical domain experts |
+| Learning Curve | Low (for Python developers) | High (new language to learn) |
+| Integration | Seamless with host language code | Requires an explicit interface/bridge |
+
+### Chapter 5: Implementation of an Internal DSL via Fluent Interfaces
+Given the goal of creating a library for Python developers, an internal DSL implemented as a fluent interface is the recommended approach. This design pattern achieves the desired chainability and expressiveness while remaining within the familiar Python ecosystem.
+
+#### 5.1. The Fluent Interface Pattern
+A fluent interface is an object-oriented API design that relies extensively on method chaining to create more readable and flowing code. The goal is to make the code read like a domain-specific language, bridging the gap between human language and programming syntax.
+
+#### 5.2. The Core Mechanism: Method Chaining
+The technical foundation of a fluent interface is method chaining. This is a programming technique where methods are called sequentially on the same object in a single statement. This is achieved by having each method in the chain return the object instance itself (typically by returning `self` in Python).
+
+A simple example of a calculator class demonstrates the principle:
+
+```python
+class Calculator:
+    def __init__(self, value=0):
+        self.value = value
+
+    def add(self, number):
+        self.value += number
+        return self  # Return the instance to enable chaining
+
+    def subtract(self, number):
+        self.value -= number
+        return self  # Return the instance
+
+    def get_result(self):
+        return self.value  # Terminating method that breaks the chain
+
+# Usage
+result = Calculator().add(10).subtract(2).get_result()
+# result is 8
+```
+
+In this example, the `add` and `subtract` methods modify the internal state of the `Calculator` instance and then return `self`, allowing the next method call to be appended. The `get_result` method is a "terminating method" that returns the final value, thus ending the chain.
+
+#### 5.3. The Builder Pattern as a Foundation
+For more complex object creation, the Builder pattern is a natural and powerful companion to the fluent interface. The Builder pattern separates the construction of a complex object from its representation, allowing the same construction process to create different representations.
+
+When implemented with a fluent interface, the builder object's methods are used to configure the properties of the object being built. Each configuration method returns the builder itself, allowing for chaining. A final `.build()` method is then called to construct and return the fully configured object.
+
+```python
+class UserBuilder:
+    def __init__(self):
+        self._username = None
+        self._email = None
+        self._is_active = False
+
+    def with_username(self, username):
+        self._username = username
+        return self
+
+    def with_email(self, email):
+        self._email = email
+        return self
+
+    def activate(self):
+        self._is_active = True
+        return self
+
+    def build(self):
+        if not self._username or not self._email:
+            raise ValueError("Username and email are required")
+        return User(self._username, self._email, self._is_active)
+
+# Usage
+user = UserBuilder().with_username("jdoe").with_email("jdoe@example.com").activate().build()
+```
+
+#### 5.4. Managing State and Preventing Invalid Chains
+A simple fluent interface where every method returns `self` can allow for invalid sequences of calls (e.g., calling a method that requires a prerequisite that hasn't been set). A more advanced and robust technique is to have methods return different types or interfaces at each step of the chain. This creates a state machine that guides the user through a valid sequence, making invalid states unrepresentable in the code.
+
+For example, an API for building an HTTP request could be designed such that after specifying the method (e.g., `POST`), the returned object exposes methods for adding a body, whereas after specifying `GET`, the returned object does not. This is enforced by the type system, providing compile-time safety and a much better developer experience than runtime checks.
+
+#### 5.5. Python Implementation
+- **Basic Chaining:** As shown in the examples above, the fundamental technique in Python is to have each chainable method return `self`.
+- **Using Libraries:** For more advanced use cases or for applying a fluent style to existing Python objects, libraries like `fluentpy` can be used. `fluentpy` provides a wrapper that enables fluent, chainable interfaces for standard library objects and functions, reducing the amount of boilerplate code required to implement this pattern. It allows for expressive, single-line data manipulation pipelines, inspired by libraries like jQuery and Lodash in JavaScript.
+
+```python
+import fluentpy as _
+
+# Example using fluentpy to chain operations on a list
+result = _(range(10)).map(_.each * 3).filter(_.each < 10)._  # result is (0, 3, 6, 9)
+```
+
+## Chapter 6: Implementation of an External DSL
+Should the project's requirements demand a syntax that cannot be accommodated within Python, or if the target audience includes non-programmers, an external DSL becomes necessary. This is a more involved process that requires building a language processing pipeline.
+
+### 6.1. The Parsing Pipeline
+Processing an external DSL involves several distinct stages:
+
+- **Lexical Analysis (Lexing):** The input text of the DSL is broken down into a sequence of "tokens." Tokens are the smallest meaningful units of the language, such as keywords (`workflow`), identifiers (`my_task`), and symbols (`{`, `}`).
+- **Syntax Analysis (Parsing):** The sequence of tokens is analyzed to determine its grammatical structure according to the rules of the DSL's grammar. The output of this stage is typically an Abstract Syntax Tree (AST), a tree-like data structure that represents the code's structure.
+- **Semantic Analysis:** The AST is traversed to check for semantic correctness. This involves verifying that the constructs are meaningful within the domain (e.g., ensuring that a specified task type is valid).
+
+### 6.2. Defining a Grammar
+The syntax of an external DSL is formally defined by a grammar. Grammars are often written in a notation like Extended Backus-Naur Form (EBNF). The grammar defines the language's vocabulary (terminal symbols) and the rules for combining them into valid structures (non-terminal symbols and production rules).
+
+### 6.3. Parser-Generator Tools in Python
+Building a parser from scratch is a complex task. Fortunately, Python has a rich ecosystem of libraries, known as parser generators, that automate this process.
+
+- **Lark:** Lark is a modern and highly recommended parsing library for Python. It uses an EBNF-style grammar and can employ powerful parsing algorithms like Earley (which can handle any context-free grammar, including ambiguous ones) or LALR(1) (which is faster for less complex grammars). A key feature of Lark is that it automatically constructs the AST from the parsed input, greatly simplifying the development process.
+- **PLY (Python Lex-Yacc):** PLY is a Python implementation of the classic Unix tools Lex (for lexing) and Yacc (for parsing). It is a robust and well-established tool but can be more verbose to use than modern alternatives like Lark.
+- **ANTLR:** ANTLR (ANother Tool for Language Recognition) is a powerful parser generator that can generate parsers in many different languages, including Python. It is well-suited for complex languages and provides excellent error recovery and reporting capabilities.
+
+### 6.4. From AST to Action: Interpretation vs. Code Generation
+Once the DSL source code has been successfully parsed into an AST, there are two primary strategies for executing it:
+
+- **Interpretation:** An interpreter is a program that directly executes the instructions represented in the AST. It traverses the tree node by node at runtime and performs the corresponding actions. Interpretation is often simpler to implement and provides a more dynamic execution model.
+- **Code Generation (Transpilation):** A code generator (or transpiler) traverses the AST and translates it into source code for a general-purpose language like Python. This generated code is then compiled and/or executed. Code generation can often result in better performance, as the output code can be optimized by the target language's compiler or runtime. It also allows the DSL to leverage the full power and ecosystem of the target language.
+
+## Part III: Blueprint for a Relational Frame Theory (RFT) Computational Library
+This part of the report addresses the unique and innovative challenge of architecting a software library based on Relational Frame Theory (RFT), a sophisticated psychological model of human language and cognition. The primary architectural task is the translation of abstract cognitive concepts into a concrete, computationally sound model.
+
+### Chapter 7: Deconstructing Relational Frame Theory for Computation
+#### 7.1. Introduction to RFT
+Relational Frame Theory (RFT) is a contemporary psychological theory from the behavior-analytic tradition that provides an account of human language and cognition. Rooted in the philosophy of functional contextualism, RFT posits that the core of human language is not based on direct learning alone, but on the ability to learn to relate stimuli in arbitrary ways. It is an extension and, in some ways, a challenge to B.F. Skinner's analysis of verbal behavior, and it provides a framework for analyzing complex human behaviors like analogy, metaphor, and rule-following.
+
+#### 7.2. Core Concept: Arbitrarily Applicable Relational Responding (AARR)
+The foundational concept of RFT is Arbitrarily Applicable Relational Responding (AARR). AARR is a learned, generalized operant behavior. In simple terms, it is the ability of humans to respond to relationships between stimuli that are not based on their physical properties but on social convention or context. For example, a non-human animal can learn to pick the physically larger of two objects. A human, however, can learn that a nickel is "larger" (in value) than a dime (which is physically smaller). This relational response ("is greater than") is applied arbitrarily, based on contextual cues, not physical form. This ability is the cornerstone of the proposed library's computational model.
+
+#### 7.3. The Three Pillars of RFT
+AARR is defined by three key properties that must be implemented as the core mechanics of the RFT library:
+
+- **Mutual Entailment:** This refers to the derived bidirectionality of stimulus relations. If a relation is learned in one direction (e.g., A is the same as B), a corresponding relation is automatically derived in the opposite direction (B is the same as A). For non-symmetrical relations, the derived relation is inverse (e.g., if A is greater than B, then B is less than A).
+- **Combinatorial Entailment:** This property describes the combination of two or more stimulus relations to derive a third, novel relation. If an individual learns that A is greater than B, and B is greater than C, they can derive without further training that A is greater than C and C is less than A. This is the basis of logical inference and reasoning within the RFT framework.
+- **Transformation of Stimulus Functions:** This is perhaps the most profound property of RFT. It states that the psychological functions of a stimulus can be altered based on its relationship to other stimuli. For example, if stimulus A has been paired with an electric shock and thus evokes fear (its function), and the individual then learns that stimulus C is the opposite of A, stimulus C may now acquire the function of evoking calm or relief, without ever having been directly paired with a pleasant experience.
+
+**Table 2: Mapping RFT Concepts to Computational Primitives**
+
+The critical first step in designing the RFT library is to establish a clear and unambiguous mapping from the abstract concepts of the theory to concrete computational primitives. This translation forms the conceptual bridge between psychology and software engineering, turning a research goal into an actionable engineering specification. The most natural computational model for representing the relational networks of RFT is a graph, where stimuli are nodes and relations are edges.
+
+| RFT Concept | Computational Primitive / Data Structure | Algorithmic Operation |
+| --- | --- | --- |
+| Stimulus | Node in a Graph | `graph.add_node(id, attributes)` |
+| Relational Frame | Edge Type / Label (e.g., `"is_greater_than"`) | `graph.add_edge(A, B, type="greater_than")` |
+| Mutual Entailment | Bidirectional Edges or Edge Inference Rule | On `add_edge(A, B, type=">")`, automatically infer `add_edge(B, A, type="<")`. |
+| Combinatorial Entailment | Graph Traversal / Pathfinding | Transitive closure algorithms or path queries. |
+| Stimulus Function | Attribute/Property on a Node (e.g., `fear_value=0.8`) | `node.set_attribute("function", value)` |
+| Transformation of Function | Attribute Propagation Algorithm | A process that traverses the graph from a source node, updating the attributes of connected nodes based on edge types and rules. |
+| Contextual Cue (Cfunc) | Graph-level State or Edge Property | Conditional logic in algorithms that activates/deactivates certain edges or rules based on the context. |
+
+### Chapter 8: An RFT-Driven Architecture - Modeling Relational Networks
+#### 8.1. The Case for a Graph-Based Model
+The structure of RFT, with its emphasis on entities (stimuli) and the connections (relations) between them, maps directly onto the mathematical concept of a graph. A graph-based data model is therefore the most natural and powerful foundation for the RFT library. In this model, stimuli are represented as nodes, and the relational frames (sameness, opposition, comparison, etc.) are represented as directed, labeled edges between these nodes. This approach allows the library to leverage decades of research in graph theory and algorithms for tasks like pathfinding (combinatorial entailment) and network traversal (transformation of functions).
+
+#### 8.2. Core Architectural Components
+The architecture of the RFT library should be organized around a few key classes that directly correspond to the components of the graph-based model:
+
+- **RelationalNetwork:** The central class of the library, acting as the container for the entire graph. It manages the collection of nodes and edges and provides the main interface for building and querying the network.
+- **StimulusNode:** A class representing a node in the graph. Each instance would have a unique identifier and a dictionary or similar structure to hold its psychological functions (e.g., `{"valence": "positive", "arousal": 0.7}`).
+- **RelationEdge:** A class representing a directed edge. Each instance would connect two `StimulusNode` objects and have a `type` attribute that specifies the relational frame (e.g., `RelationType.OPPOSITE`, `RelationType.GREATER_THAN`).
+- **Context:** An object that encapsulates the contextual cues (Cfuncs in RFT terminology) that govern the application of relational frames. For example, a context might specify that in a "financial" context, the relation "greater than" applies to monetary value, while in a "physical" context, it applies to size.
+
+#### 8.3. Implementing the Three Pillars
+The three core properties of RFT should be implemented as distinct, interacting engines within the library's architecture:
+
+- **Entailment Engine:** This module is responsible for enforcing the logic of mutual and combinatorial entailment. It would be triggered whenever a new relation (edge) is added to the `RelationalNetwork`. For mutual entailment, it would automatically create the inverse edge (e.g., adding `A > B` triggers the creation of `B < A`). For combinatorial entailment, it would perform graph traversal or apply transitive closure algorithms to discover and add new, derived edges to the network (e.g., if `A > B` and `B > C` exist, it creates `A > C`).
+- **Function Transformation Engine:** This module implements the transformation of stimulus functions. It would contain a set of rules that define how functions propagate across different types of relations (e.g., "for an OPPOSITE relation, invert the valence"). The engine would provide a method that, given a source node with an active function, traverses the graph and applies these rules to update the functions of related nodes. This could be implemented using algorithms like Breadth-First Search (BFS) or Depth-First Search (DFS) to explore the network from the source stimulus.
+
+## Chapter 9: A Fluent API for Relational Reasoning
+#### 9.1. Design Goals for an RFT API
+The API for the RFT library should be designed to be as intuitive as possible, allowing users to construct and interact with relational networks in a way that feels natural and mirrors the cognitive processes described by the theory. It should hide the underlying complexity of graph manipulation and provide a high-level, expressive language for relational reasoning. A fluent, chainable API is not merely a convenient design choice here; it is the most conceptually aligned way to represent the theory's core process. RFT describes language and cognition as being built by sequentially relating one thing to another. A fluent API mirrors this constructive, step-by-step process, making the code itself a direct representation of a cognitive act.
+
+#### 9.2. Building the Network with Chains
+The primary interface for creating a `RelationalNetwork` should be a fluent builder. This allows users to define stimuli and their relations in a single, readable expression.
+
+```python
+from rft_library import RFTBuilder, functions
+
+# Define a network using a fluent, chainable API
+network = (
+    RFTBuilder()
+    .stimulus("DIME", properties={"physical_size": 5})
+    .stimulus("NICKEL", properties={"physical_size": 10})
+    .stimulus("CANDY", functions={functions.REINFORCING: 0.8})
+    .context("MONETARY")
+    .relate("NICKEL").is_less_than("DIME")
+    .context("PHYSICAL")
+    .relate("NICKEL").is_greater_than("DIME")
+    .context_free()
+    .relate("DIME").is_same_as("CANDY")
+    .build()
+)
+```
+
+This API makes the process of network construction explicit and readable. It allows for the definition of stimuli with inherent properties and functions, and the establishment of relations under specific contextual controls.
+
+#### 9.3. Querying and Transforming with Chains
+Interacting with the constructed network should also be handled through a fluent API, separating the acts of querying derived relations from triggering function transformations.
+
+```python
+# Query for a derived relation under a specific context
+# Given NICKEL < DIME and DIME == CANDY, we can derive NICKEL < CANDY
+relation = network.query(context="MONETARY").get_relation_between("NICKEL", "CANDY")
+# relation would be 'is_less_than'
+
+# Trigger and observe the transformation of stimulus functions
+# If CANDY is reinforcing, and DIME is the same as CANDY, DIME should become reinforcing.
+transformed_network = network.transform().from_stimulus("CANDY").propagate_functions()
+
+dime_functions = transformed_network.get_functions_of("DIME")
+# dime_functions should now include a reinforcing function
+```
+
+This design provides a clear, expressive, and powerful interface for working with the computational model of RFT, making a complex theory accessible to researchers and developers through an intuitive and chainable API.
+
+## Part IV: Engineering for Longevity and Reliability
+This final part provides the essential engineering practices required to ensure that both the general-purpose DSL library and the specialized RFT library are robust, maintainable, and usable over the long term. These practices are non-negotiable for software of this scale and complexity.
+
+### Chapter 10: A Comprehensive Multi-Layered Testing Strategy
+A rigorous and multi-layered testing strategy is the primary defense against regressions and bugs in a large library. Ad-hoc testing is insufficient; a systematic approach is required.
+
+#### 10.1. The Testing Pyramid for Libraries
+The testing pyramid is a model for structuring a test suite to be both comprehensive and efficient. For a library, it can be adapted as follows:
+
+- **Unit Tests (Base of the Pyramid):** These are the most numerous tests. They verify the correctness of individual functions, methods, and classes in isolation. They should be fast and focused. Dependencies are often replaced with test doubles (mocks or stubs) to ensure isolation.
+- **Integration Tests (Middle of the Pyramid):** These tests verify the interactions between different internal modules of the library. For example, an integration test would confirm that the public API layer correctly calls the core logic layer and that the core logic layer correctly uses the utility layer. These tests are crucial for catching issues at the boundaries between components.
+- **End-to-End (API-level) Tests (Top of the Pyramid):** These are the least numerous but most comprehensive tests. They test the library's public API from a user's perspective, making calls to the public functions and asserting that the final, observable outcome is correct. These tests treat the library as a black box and validate complete workflows or chains of calls.
+
+#### 10.2. Advanced Testing for Fluent APIs and Stateful Systems
+Fluent APIs and other stateful systems present a significant testing challenge: the number of possible sequences of method calls is combinatorially explosive, and the behavior of any given call depends on the sequence of calls that preceded it. Exhaustively testing all possible chains is impossible.
+
+- **The Challenge of Stateful Testing:** Traditional example-based testing (writing individual test cases for specific scenarios) is inadequate for covering the vast state space of a fluent API. It is easy to miss subtle edge cases that arise from unusual but valid combinations of calls.
+- **Property-Based Testing with Hypothesis:** Property-based testing is a powerful technique for addressing this challenge. Instead of writing tests for specific inputs, the developer defines general properties or invariants that should hold true for all valid inputs. A library like Hypothesis then automatically generates hundreds or thousands of random, and often devious, inputs in an attempt to find a counterexample that falsifies the property.
+- **Stateful Testing with `RuleBasedStateMachine`:** For fluent APIs, Hypothesis provides an even more powerful tool: `RuleBasedStateMachine`. This feature allows the developer to model the system under test as a state machine.
+  - **Define Rules:** Each method in the fluent API is defined as a `@rule` within the state machine class. Each rule can specify strategies for its arguments.
+  - **Define Invariants:** Invariants are properties that must be true after every step (i.e., after every method call). For example, an invariant for a builder might be that the object is in a valid intermediate state.
+  - **Hypothesis Generates Chains:** Hypothesis then acts as an intelligent "chaos monkey," generating random sequences of rule calls (i.e., random method chains) and checking the invariants after each call. If it finds a sequence that breaks an invariant, it automatically simplifies the failing chain to the smallest possible example, making debugging straightforward. This is the most effective known strategy for rigorously testing the robustness of the complex, chainable APIs requested by the user.
+
+#### 10.3. Testing the RFT Library
+The RFT library, with its complex internal state (the relational network) and logic (entailment and transformation engines), is a prime candidate for advanced testing techniques.
+
+- **Model-Based Testing:** A common strategy for testing complex systems is to compare their behavior against a much simpler, "model" implementation that is obviously correct but not performant. For the RFT library, one could create a simple model of the relational network using basic Python dictionaries and lists. The stateful tests would then perform each action on both the real, optimized graph implementation and the simple model, asserting at each step that their states remain equivalent.
+- **Testing Invariants:** The RFT library's behavior is governed by strong theoretical principles that can be translated directly into testable invariants. For example:
+  - `invariant_mutual_entailment()`: For any edge `A -> B` with type `T`, an inverse edge `B -> A` with type `inverse(T)` must exist.
+  - `invariant_transitivity()`: If a path exists from `A` to `C` via `B`, a directly derived edge from `A` to `C` must exist.
+
+Hypothesis can then be used to relentlessly attack the system, searching for any sequence of operations that could possibly violate these fundamental rules.
+
+### Chapter 11: Lifecycle Management - Versioning, Documentation, and Community
+A library's success depends not only on its technical excellence but also on how it is managed and presented to its users over its lifecycle.
+
+#### 11.1. Semantic Versioning (SemVer)
+To manage user expectations and allow for safe dependency management, the library must strictly adhere to Semantic Versioning (SemVer). The version number, formatted as `MAJOR.MINOR.PATCH`, communicates the nature of changes:
+
+- **MAJOR** (e.g., `1.7.2 -> 2.0.0`): Incremented for incompatible API changes. This signals to users that upgrading will require them to modify their code.
+- **MINOR** (e.g., `1.7.2 -> 1.8.0`): Incremented when new, backwards-compatible functionality is added. Users can upgrade safely without breaking existing code.
+- **PATCH** (e.g., `1.7.2 -> 1.7.3`): Incremented for backwards-compatible bug fixes. These are safe, essential updates.
+
+Adherence to SemVer is a contract with the user community that builds trust and predictability.
+
+#### 11.2. Rigorous Documentation Standards
+Documentation is not an afterthought; it is an integral part of the product. For a large library, comprehensive documentation is essential for adoption and usability.
+
+- **Types of Documentation:** A complete documentation suite includes several types:
+  - **Tutorials / Getting Started Guides:** Narrative-driven guides that walk new users through solving a real problem.
+  - **Topical Guides:** In-depth explanations of key concepts and features.
+  - **API Reference:** Exhaustive, auto-generated documentation (e.g., from docstrings using Sphinx) that details every public class, function, and method.
+  - **Contribution Guide:** Documentation for developers who want to contribute to the library, outlining coding standards, testing procedures, and the pull request process.
+- **Best Practices:** Effective documentation is clear, concise, and accurate. It uses simple language, avoids jargon where possible, provides numerous copy-pasteable code examples for common use cases, and is kept rigorously up-to-date with every code change.
+
+#### 11.3. Deployment and Distribution
+The standard mechanism for distributing a Python library is the Python Package Index (PyPI). The packaging process should be modernized to use a `pyproject.toml` file, which is the current standard for specifying package metadata and build dependencies, replacing the older `setup.py` and `requirements.txt` files for this purpose.
+
+#### 11.4. Long-Term Maintenance Strategy
+A plan for long-term maintenance is crucial for the library's continued health and relevance.
+
+- **Issue Tracking:** Use a public issue tracker (e.g., GitHub Issues) to manage bug reports and feature requests.
+- **Code Review Process:** All changes to the codebase, whether from core maintainers or external contributors, must go through a mandatory code review process. This ensures code quality, consistency, and knowledge sharing among the team.
+- **Contribution Guidelines:** A clear `CONTRIBUTING.md` file should set expectations for contributors regarding coding style, testing requirements, and the process for submitting changes. This makes it easier for the community to participate in the library's development.
+- **Dedicated Maintainership:** A common library must have a dedicated maintainer or team responsible for its stewardship. This team is responsible for reviewing contributions, managing releases, and guiding the library's architectural evolution. Without dedicated ownership, a shared library will inevitably degrade over time.
+
+## Conclusions
+The architecture of a large-scale software library is a deliberate act of managing complexity. This report has laid out a comprehensive blueprint for constructing two such libraries—a general-purpose DSL and a novel RFT-based computational system—founded on a set of core principles.
+
+First, a monolithic architecture is the appropriate choice for a library, but it demands rigorous internal structure. This structure is best achieved through a hybrid of architectural patterns, adapting the principles of Layered Architecture, Domain-Driven Design, and even Microservices to create a system of highly cohesive, loosely coupled internal modules. This disciplined internal design is the key to preventing a large codebase from becoming unmaintainable.
+
+Second, the public API is the product. For a library with a vast surface area, a fluent interface implemented via method chaining provides an expressive and intuitive user experience, effectively creating an internal Domain-Specific Language. This approach, especially when guided by patterns like the Builder and stateful type transitions, transforms a collection of functions into a coherent language for solving domain problems. For the highly specialized RFT library, this fluent design is not merely an aesthetic choice but a direct computational metaphor for the cognitive processes the library aims to model.
+
+Third, advanced challenges require advanced engineering practices. The combinatorial complexity of stateful, chainable APIs renders traditional testing methods insufficient. A modern testing strategy must be anchored by property-based testing, specifically using tools like Hypothesis's `RuleBasedStateMachine` to automatically explore the vast state space and discover edge-case failures that would be impossible to find manually.
+
+Finally, a library's lifecycle extends far beyond its initial implementation. Long-term success is contingent on disciplined engineering practices, including strict adherence to Semantic Versioning, the creation of comprehensive, multi-faceted documentation, and a clear strategy for community engagement and maintenance.
+
+By integrating these architectural, design, and engineering principles, it is possible to construct libraries that are not only powerful and feature-rich but also scalable, maintainable, and a pleasure to use, ensuring their value and relevance for years to come.

--- a/PUMA ARC 2025/NEW_FEATURES.md
+++ b/PUMA ARC 2025/NEW_FEATURES.md
@@ -2,10 +2,11 @@
 
 ## Overview
 
-Two major new features have been added:
+Three major new features have been added:
 
 1. **Playground Evaluation Suite** - Learn from failures on evaluation challenges
 2. **RFT Entailment Engine** - Automatic rule inference via mutual and combinatorial entailment
+3. **Architecting Abstraction Blueprint** - Comprehensive architectural playbook for large-scale libraries and the RFT DSL stack (`Architecting_Abstraction.md`).
 
 ---
 

--- a/PUMA ARC 2025/PUMA/.gitignore
+++ b/PUMA ARC 2025/PUMA/.gitignore
@@ -55,6 +55,7 @@ eval_*.py
 build_*.py
 fix_*.py
 emergency_*.py
+!arc_solver/tests/test_architecting_abstraction_doc.py
 
 # Facts data
 facts.jsonl

--- a/PUMA ARC 2025/PUMA/arc_solver/tests/test_architecting_abstraction_doc.py
+++ b/PUMA ARC 2025/PUMA/arc_solver/tests/test_architecting_abstraction_doc.py
@@ -1,0 +1,80 @@
+"""Regression tests for the architecting abstraction dossier."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from hypothesis import given, strategies as st
+
+from arc_solver.utils import (
+    DocumentMetrics,
+    compute_document_metrics,
+    emit_document_metrics,
+)
+
+DOC_PATH = Path(__file__).resolve().parents[3] / "Architecting_Abstraction.md"
+DOC_TEXT = DOC_PATH.read_text(encoding="utf-8")
+
+EXPECTED_HEADINGS = [
+    "Part I: Architectural Foundations for Large-Scale Libraries",
+    "Chapter 1: Taming Complexity - Architectural Patterns for Monolithic Libraries",
+    "Chapter 2: The Art of the API - Principles of Modern Library Design",
+    "Chapter 3: Pythonic Structure at Scale",
+    "Part II: Blueprint for a General-Purpose Library with 1,000 Functions & Chains",
+    "Chapter 4: The DSL Decision - Internal vs. External Languages",
+    "Chapter 5: Implementation of an Internal DSL via Fluent Interfaces",
+    "Chapter 6: Implementation of an External DSL",
+    "Part III: Blueprint for a Relational Frame Theory (RFT) Computational Library",
+    "Chapter 7: Deconstructing Relational Frame Theory for Computation",
+    "Chapter 8: An RFT-Driven Architecture - Modeling Relational Networks",
+    "Chapter 9: A Fluent API for Relational Reasoning",
+    "Part IV: Engineering for Longevity and Reliability",
+    "Chapter 10: A Comprehensive Multi-Layered Testing Strategy",
+    "Chapter 11: Lifecycle Management - Versioning, Documentation, and Community",
+    "Conclusions",
+]
+
+
+@pytest.fixture(scope="session")
+def doc_metrics() -> DocumentMetrics:
+    return compute_document_metrics(DOC_PATH, expected_headings=EXPECTED_HEADINGS)
+
+
+def test_document_exists() -> None:
+    assert DOC_PATH.is_file(), "The architecting abstraction dossier must be present."
+
+
+def test_metrics_counts_are_positive(doc_metrics) -> None:
+    assert doc_metrics.total_words > 1000
+    assert doc_metrics.heading_count >= len(EXPECTED_HEADINGS)
+    assert doc_metrics.progress_marker_count >= 2
+
+
+@given(st.sampled_from(EXPECTED_HEADINGS))
+def test_each_heading_occurs_once(heading: str) -> None:
+    assert DOC_TEXT.count(heading) == 1
+
+
+def test_emit_document_metrics_logs_json(monkeypatch, caplog, doc_metrics) -> None:
+    monkeypatch.delenv("ARC_ARCH_DOC_METRICS_ENABLED", raising=False)
+    with caplog.at_level("INFO", logger="arc.doc_metrics"):
+        emit_document_metrics(doc_metrics, correlation_id="ci-123")
+    record = next(
+        entry for entry in caplog.records if entry.name == "arc.doc_metrics"
+    )
+    payload = json.loads(record.message)
+    assert payload["event"] == "architecting_abstraction_metrics"
+    assert payload["metrics"]["total_words"] == doc_metrics.total_words
+    assert payload["correlation_id"] == "ci-123"
+
+
+def test_emit_document_metrics_respects_feature_flag(monkeypatch, caplog, doc_metrics) -> None:
+    monkeypatch.setenv("ARC_ARCH_DOC_METRICS_ENABLED", "0")
+    with caplog.at_level("DEBUG", logger="arc.doc_metrics"):
+        emit_document_metrics(doc_metrics, correlation_id="ci-flagged")
+    assert any(
+        entry.message == "architecting_abstraction_metrics_disabled"
+        for entry in caplog.records
+    )

--- a/PUMA ARC 2025/PUMA/arc_solver/utils/__init__.py
+++ b/PUMA ARC 2025/PUMA/arc_solver/utils/__init__.py
@@ -1,3 +1,17 @@
 """Utility helpers for the ARC solver package."""
 
 # [S:PKG v1] module=arc_solver.utils status=initialised pass
+
+from .documentation import (
+    DocumentMetrics,
+    DocumentMetricsError,
+    compute_document_metrics,
+    emit_document_metrics,
+)
+
+__all__ = [
+    "DocumentMetrics",
+    "DocumentMetricsError",
+    "compute_document_metrics",
+    "emit_document_metrics",
+]

--- a/PUMA ARC 2025/PUMA/arc_solver/utils/documentation.py
+++ b/PUMA ARC 2025/PUMA/arc_solver/utils/documentation.py
@@ -1,0 +1,132 @@
+"""Utility helpers for validating long-form architectural documentation."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Sequence
+
+# [S:OBS v1] emitter=doc_metrics_logger channel=structured pass
+LOG = logging.getLogger("arc.doc_metrics")
+
+_PROGRESS_MARKER_PATTERN = re.compile(r"\[S:[A-Z]+ v\d+\][^\n]* pass", re.IGNORECASE)
+_HEADING_PATTERN = re.compile(r"^#{1,6} (.+)$", re.MULTILINE)
+
+
+class DocumentMetricsError(RuntimeError):
+    """Raised when documentation invariants fail validation."""
+
+
+@dataclass(frozen=True)
+class DocumentMetrics:
+    """Computed statistics for a documentation artifact."""
+
+    total_words: int
+    total_characters: int
+    heading_count: int
+    progress_marker_count: int
+
+    def as_dict(self) -> Dict[str, int]:
+        """Return a JSON-serialisable view of the metrics."""
+
+        return {
+            "total_words": self.total_words,
+            "total_characters": self.total_characters,
+            "heading_count": self.heading_count,
+            "progress_marker_count": self.progress_marker_count,
+        }
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def _normalise_path(doc_path: Path) -> Path:
+    resolved = doc_path.expanduser().resolve()
+    try:
+        resolved.relative_to(_repo_root())
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise DocumentMetricsError(
+            f"Document path {resolved} escapes repository root"  # noqa: EM102
+        ) from exc
+    if not resolved.is_file():
+        raise DocumentMetricsError(f"Document path {resolved} is not a file")
+    return resolved
+
+
+def _load_text(doc_path: Path) -> str:
+    try:
+        return doc_path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - IO failures are exceptional
+        raise DocumentMetricsError(f"Failed to read document {doc_path}") from exc
+
+
+def _validate_headings(text: str, expected_headings: Sequence[str] | None) -> List[str]:
+    headings = [match.group(1).strip() for match in _HEADING_PATTERN.finditer(text)]
+    if expected_headings:
+        missing = [heading for heading in expected_headings if heading not in headings]
+        if missing:
+            raise DocumentMetricsError(
+                "Missing required headings: " + ", ".join(sorted(missing))
+            )
+    return headings
+
+
+def _count_words(text: str) -> int:
+    return len([token for token in re.split(r"\s+", text.strip()) if token])
+
+
+def _should_emit_metrics() -> bool:
+    return os.getenv("ARC_ARCH_DOC_METRICS_ENABLED", "1") not in {"0", "false", "False"}
+
+
+def compute_document_metrics(
+    doc_path: Path | str,
+    *,
+    expected_headings: Sequence[str] | None = None,
+) -> DocumentMetrics:
+    """Compute validated metrics for the supplied documentation path."""
+
+    path = _normalise_path(Path(doc_path))
+    text = _load_text(path)
+    headings = _validate_headings(text, expected_headings)
+    progress_markers = _PROGRESS_MARKER_PATTERN.findall(text)
+    metrics = DocumentMetrics(
+        total_words=_count_words(text),
+        total_characters=len(text),
+        heading_count=len(headings),
+        progress_marker_count=len(progress_markers),
+    )
+    if metrics.heading_count == 0:
+        raise DocumentMetricsError("Documentation must include at least one heading")
+    return metrics
+
+
+def emit_document_metrics(metrics: DocumentMetrics, *, correlation_id: str | None = None) -> None:
+    """Emit structured metrics to the shared logger if enabled."""
+
+    if not _should_emit_metrics():
+        LOG.debug(
+            "architecting_abstraction_metrics_disabled",
+            extra={"correlation_id": correlation_id},
+        )
+        return
+    payload: Dict[str, object] = {
+        "event": "architecting_abstraction_metrics",
+        "metrics": metrics.as_dict(),
+    }
+    if correlation_id:
+        payload["correlation_id"] = correlation_id
+    LOG.info(json.dumps(payload, sort_keys=True))
+
+
+__all__ = [
+    "DocumentMetrics",
+    "DocumentMetricsError",
+    "compute_document_metrics",
+    "emit_document_metrics",
+]

--- a/PUMA ARC 2025/scripts/architecting_abstraction_metrics.py
+++ b/PUMA ARC 2025/scripts/architecting_abstraction_metrics.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Emit observability metrics for the architecting abstraction dossier."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import List
+
+PROJECT_PYTHON_ROOT = Path(__file__).resolve().parents[1] / "PUMA"
+if str(PROJECT_PYTHON_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_PYTHON_ROOT))
+
+# [S:OBS v1] cli=architecting_abstraction_metrics status=shipping pass
+from arc_solver.utils import (
+    DocumentMetricsError,
+    compute_document_metrics,
+    emit_document_metrics,
+)
+
+_LOGGER = logging.getLogger("arc.doc_metrics.cli")
+
+_REQUIRED_HEADINGS: List[str] = [
+    "Part I: Architectural Foundations for Large-Scale Libraries",
+    "Chapter 1: Taming Complexity - Architectural Patterns for Monolithic Libraries",
+    "Chapter 2: The Art of the API - Principles of Modern Library Design",
+    "Chapter 3: Pythonic Structure at Scale",
+    "Part II: Blueprint for a General-Purpose Library with 1,000 Functions & Chains",
+    "Chapter 4: The DSL Decision - Internal vs. External Languages",
+    "Chapter 5: Implementation of an Internal DSL via Fluent Interfaces",
+    "Chapter 6: Implementation of an External DSL",
+    "Part III: Blueprint for a Relational Frame Theory (RFT) Computational Library",
+    "Chapter 7: Deconstructing Relational Frame Theory for Computation",
+    "Chapter 8: An RFT-Driven Architecture - Modeling Relational Networks",
+    "Chapter 9: A Fluent API for Relational Reasoning",
+    "Part IV: Engineering for Longevity and Reliability",
+    "Chapter 10: A Comprehensive Multi-Layered Testing Strategy",
+    "Chapter 11: Lifecycle Management - Versioning, Documentation, and Community",
+    "Conclusions",
+]
+
+
+def _default_doc_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "Architecting_Abstraction.md"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Compute and emit structured metrics for the architecting abstraction dossier",
+    )
+    parser.add_argument(
+        "doc_path",
+        nargs="?",
+        default=_default_doc_path(),
+        type=Path,
+        help="Path to the Markdown dossier (defaults to project copy).",
+    )
+    parser.add_argument(
+        "--correlation-id",
+        dest="correlation_id",
+        default=None,
+        help="Optional correlation identifier for log aggregation.",
+    )
+    return parser
+
+
+def main(argv: List[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s", force=True)
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        metrics = compute_document_metrics(
+            args.doc_path,
+            expected_headings=_REQUIRED_HEADINGS,
+        )
+    except DocumentMetricsError as exc:
+        _LOGGER.error(
+            "architecting_abstraction_metrics_failed", extra={"error": str(exc)}
+        )
+        return 1
+    emit_document_metrics(metrics, correlation_id=args.correlation_id)
+    print(json.dumps(metrics.as_dict(), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add the Architecting_Abstraction.md dossier covering layered architecture, DSL decisions, and RFT blueprinting with shipped progress markers
- wire reusable documentation metrics utilities and CLI emission script for structured observability
- register property-based regression tests and un-ignore the test path while noting the new blueprint in NEW_FEATURES.md

## Testing
- `python PUMA ARC 2025/scripts/architecting_abstraction_metrics.py`
- `PYTHONPATH="PUMA ARC 2025/PUMA" python -m pytest "PUMA ARC 2025/PUMA/arc_solver/tests/test_architecting_abstraction_doc.py"`


------
https://chatgpt.com/codex/tasks/task_e_68e4a515c9308322a4217cfb9918dfd5